### PR TITLE
Initialize blocklight properly

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -274,7 +274,16 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1400,7 @@
+@@ -1266,6 +1285,8 @@
+     public void func_150809_p()
+     {
+         this.field_76646_k = true;
++        net.minecraftforge.common.lighting.LightingHooks.initChunkLighting(this, this.field_76637_e);
++        if (true) return;
+         this.field_150814_l = true;
+         BlockPos blockpos = new BlockPos(this.field_76635_g << 4, 0, this.field_76647_h << 4);
+ 
+@@ -1381,7 +1402,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -283,7 +292,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1489,4 +1508,34 @@
+@@ -1489,4 +1510,34 @@
          QUEUED,
          CHECK;
      }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
@@ -1,0 +1,67 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.lighting;
+
+import net.minecraft.util.math.BlockPos.PooledMutableBlockPos;
+import net.minecraft.world.EnumSkyBlock;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+
+public class LightingHooks
+{
+    public static void initChunkLighting(final Chunk chunk, final World world)
+    {
+        final int xBase = chunk.x << 4;
+        final int zBase = chunk.z << 4;
+
+        final PooledMutableBlockPos pos = PooledMutableBlockPos.retain(xBase, 0, zBase);
+
+        if (world.isAreaLoaded(pos.add(-16, 0, -16), pos.add(31, 255, 31), false))
+        {
+            final ExtendedBlockStorage[] extendedBlockStorage = chunk.getBlockStorageArray();
+
+            for (int j = 0; j < extendedBlockStorage.length; ++j)
+            {
+                if (extendedBlockStorage[j] == Chunk.NULL_BLOCK_STORAGE)
+                    continue;
+
+                for (int x = 0; x < 16; ++x)
+                {
+                    for (int z = 0; z < 16; ++z)
+                    {
+                        for (int y = j << 4; y < (j + 1) << 4; ++y)
+                        {
+                            if (chunk.getBlockState(x, y, z).getLightValue(world, pos.setPos(xBase + x, y, zBase + z)) > 0)
+                                world.checkLightFor(EnumSkyBlock.BLOCK, pos);
+                        }
+                    }
+                }
+            }
+
+            if (world.provider.hasSkyLight())
+                chunk.setSkylightUpdated();
+
+            chunk.setLightPopulated(true);
+        }
+
+        pos.release();
+    }
+}

--- a/src/main/resources/forge_at.cfg
+++ b/src/main/resources/forge_at.cfg
@@ -25,6 +25,8 @@ public net.minecraft.world.chunk.storage.AnvilChunkLoader field_75825_d # chunkS
 public net.minecraft.world.gen.ChunkProviderServer field_73247_e # currentChunkLoader
 # World
 public-f net.minecraft.world.World field_72982_D #villageCollectionObj
+# Chunk
+public net.minecraft.world.chunk.Chunk func_177441_y()V #setSkylightUpdated
 # Biome
 public net.minecraft.world.biome.Biome *() #Everything protected->public
 public net.minecraft.world.biome.BiomeForest *()


### PR DESCRIPTION
This PR initializes the blocklight for all chunks properly.
Vanilla does some sort of (really convoluted) initialization of blocklight for worlds that do have skylight. This is done in "Chunk.checkLight()". If the world doesn't have skylight, the chunks are sent to the client with empty blocklight and then corrected by "enqueueRelightChecks()". This however produces quite derpy results in the Nether because it takes quite a while before all light sources are checked. This leaves dark spots everywhere.

This PR cleans up "Chunk.checkLight()" and calls "World.checkLightFor(...)" for all blocklight sources. This gives much better looking results for the Nether lighting.
I have rewritten the method completely (as "LightingHooks.initChunkLighting(...)" because the Vanilla version is quite convoluted, so the patches would have become quite messy. The skylight part is completely handled by "Chunk.setSkylightUpdated()". The logic in "Chunk.checkLight()" doesn't add any new checks.

Because this PR adds some additional calls to "World.checkLightFor()" I profiled the code to see if anything got slowed down. The server thread took additional ~5% of the total time for the additional light checks in the Nether, which is ok in my opinion, given the much better looking lighting. Also, due to the removal of the convoluted logic of "Chunk.checkLight()" the code got actually ~15% faster for the Overworld. Moreover, "enqueueRelightChecks()" took ~15-20% less time on the client thread in the Nether, probably because the lighting engine had less work to do, as some of it was already done by the server thread.
So, the overall performance even increased.

There are still some lighting bugs left:

 - Due to the 16 block spreading limitation of the Vanilla lighting engine (see #4263), the light will still be derpy above big lava lakes in the Nether. This is fixed by #4263
 - The Vanilla lighting engine requires chunks in a 17 block radius to be loaded. The "isAreaLoaded(...)" check however only guarantees 16 blocks, so there may still be a few dark spots left. This is fixed by #4263 and #4264
 - When the chunk is marked as light populated, the light of the neighbor chunks may not have been initialized yet, so contributions from there may be missing.

### Remarks:

#4263 requires this PR as a prerequisite: The sloppy correction done by "enqueueRelightChecks()" does not work for our LightingEngine, because we don't correct errors on the fly to achieve better performance. (Tanks mrgrim for pointing out the issue)
Should I move LightingHooks.initChunkLighting(...) to Chunk to avoid the AT?