### PR TITLE
Fix spider/chicken jockeys being unable to spawn naturally (MC-103516)

### DIFF
--- a/patches/minecraft/net/minecraft/world/World.java.patch
+++ b/patches/minecraft/net/minecraft/world/World.java.patch
@@ -523,6 +523,15 @@
                  p_72866_1_.func_70071_h_();
              }
          }
+@@ -1914,7 +2066,7 @@
+         {
+             Entity entity4 = list.get(j2);
+ 
+-            if (!entity4.field_70128_L && entity4.field_70156_m && entity4 != p_72917_2_ && (p_72917_2_ == null || entity4.func_184223_x(p_72917_2_)))
++            if (!entity4.field_70128_L && entity4.field_70156_m && entity4 != p_72917_2_ && (p_72917_2_ == null || !entity4.func_184223_x(p_72917_2_))) // Forge: fix MC-103516
+             {
+                 return false;
+             }
 @@ -2011,6 +2163,11 @@
                              blockpos$pooledmutableblockpos.func_185344_t();
                              return true;


### PR DESCRIPTION
Fix for vanilla bug [MC-103516](https://bugs.mojang.com/browse/MC-103516).

Currently, "World.checkNoEntityCollision" returns false (indicating a collision) if "Entity.isRidingSameEntity" returns true.

This prevents entities from naturally spawning with a rider correctly.

The fix is to reverse that logic, which is consistent with the usage seen in "World.getCollisionBoxes".

Tested the changes by modifing "EntitySpider.onInitialSpawn" to always spawn with a rider.

Without the change, no spiders spawn naturally at all, but you can see the skeletons that are supposed to be riding them fall to the ground as they spawn in.

With the change, you'll see spider jockeys as expected.